### PR TITLE
Modernise configure.ac and allow cadaver to regenerate its build system from source

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ AC_TYPE_UNSIGNED_LONG_LONG_INT
 
 AC_CHECK_HEADERS(sys/time.h fcntl.h pwd.h stdarg.h vmsdir.h memory.h alloca.h ncurses.h sgtty.h termios.h termio.h locale.h)
 
-AC_CHECK_FUNCS(strdup strerror memcpy strcoll tcsetattr getpass stty fchmod strtoull gettimeofday)
+AC_CHECK_FUNCS(strdup strerror memcpy strcoll tcsetattr getpass stty fchmod strtoull gettimeofday secure_getenv)
 
 AM_GNU_GETTEXT_VERSION([0.20])
 AM_GNU_GETTEXT([external])

--- a/configure.ac
+++ b/configure.ac
@@ -62,8 +62,6 @@ AC_LIBOBJ(lib/getopt1)])
 dnl Check for strcasecmp
 AC_CHECK_FUNC(strcasecmp,,[AC_LIBOBJ(lib/strcasecmp)])
 
-jm_PREREQ_TEMPNAME
-
 NEON_REPLACE_SNPRINTF()
 
 AC_FUNC_FNMATCH
@@ -77,8 +75,6 @@ AC_TYPE_UNSIGNED_LONG_LONG_INT
 
 AC_CHECK_FUNCS(strdup strerror memcpy strcoll tcsetattr getpass stty fchmod strtoull)
 AC_CHECK_HEADERS(sys/time.h pwd.h stdarg.h vmsdir.h memory.h alloca.h ncurses.h sgtty.h termios.h termio.h locale.h)
-
-jm_FUNC_STRFTIME()
 
 AM_GNU_GETTEXT_VERSION([0.20])
 AM_GNU_GETTEXT([external])

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,7 @@ AC_CHECK_HEADERS(sys/time.h pwd.h stdarg.h vmsdir.h memory.h alloca.h ncurses.h 
 
 jm_FUNC_STRFTIME()
 
+AM_GNU_GETTEXT_VERSION([0.20])
 AM_GNU_GETTEXT([external])
 
 if test "$USE_NLS" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -19,8 +19,6 @@ AC_LANG([C])
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
 
-AC_HEADER_STDC
-
 AC_ARG_ENABLE(debugging,
 AS_HELP_STRING([--disable-debugging], [disable runtime debugging messages]),,
     enable_debug=yes)

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_INIT([cadaver],[0.23.3],[cadaver@webdav.org])
 
 AC_CONFIG_SRCDIR(src/cadaver.c)
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIRS([m4 m4/neon])
 
 AC_USE_SYSTEM_EXTENSIONS
 

--- a/configure.ac
+++ b/configure.ac
@@ -11,13 +11,13 @@ AC_USE_SYSTEM_EXTENSIONS
 
 AC_DEFINE([_GNU_SOURCE], 1, [Define to enable GNU extensions])
 
-NEON_WITH_LIBS
-
 AC_PROG_CC
 AC_PROG_INSTALL
 AC_LANG([C])
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
+
+PKG_PROG_PKG_CONFIG
 
 AC_ARG_ENABLE(debugging,
 AS_HELP_STRING([--disable-debugging], [disable runtime debugging messages]),,
@@ -32,6 +32,8 @@ CHECK_READLINE()
 AC_ARG_ENABLE(netrc,
 AS_HELP_STRING([--disable-netrc],[enable .netrc support]),,
     enable_netrc=yes)
+
+NEON_WITH_LIBS
 
 NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32])
 

--- a/configure.ac
+++ b/configure.ac
@@ -71,8 +71,6 @@ fi
 
 AC_HEADER_DIRENT
 
-AC_TYPE_SIGNAL
-
 AC_TYPE_UNSIGNED_LONG_LONG_INT
 
 AC_CHECK_FUNCS(strdup strerror memcpy strcoll tcsetattr getpass stty fchmod strtoull)

--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ AC_HEADER_DIRENT
 
 AC_TYPE_UNSIGNED_LONG_LONG_INT
 
-AC_CHECK_HEADERS(sys/time.h pwd.h stdarg.h vmsdir.h memory.h alloca.h ncurses.h sgtty.h termios.h termio.h locale.h)
+AC_CHECK_HEADERS(sys/time.h fcntl.h pwd.h stdarg.h vmsdir.h memory.h alloca.h ncurses.h sgtty.h termios.h termio.h locale.h)
 
 AC_CHECK_FUNCS(strdup strerror memcpy strcoll tcsetattr getpass stty fchmod strtoull gettimeofday)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 dnl configure script
 
-AC_PREREQ(2.53)
-AC_INIT(cadaver, 0.23.3, cadaver@webdav.org)
+AC_PREREQ([2.71])
+AC_INIT([cadaver],[0.23.3],[cadaver@webdav.org])
 
 AC_CONFIG_SRCDIR(src/cadaver.c)
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 AC_USE_SYSTEM_EXTENSIONS
 
@@ -15,15 +15,15 @@ NEON_WITH_LIBS
 AC_ISC_POSIX
 AC_PROG_CC
 AC_PROG_INSTALL
-AC_LANG_C
-AC_SET_MAKE
+AC_LANG([C])
+AC_PROG_MAKE_SET
 AC_PROG_RANLIB
 
 AC_HEADER_STDC
 
 AC_ARG_ENABLE(debugging,
-AC_HELP_STRING([--disable-debugging],[disable runtime debugging messages]),,
-enable_debug=yes)
+AS_HELP_STRING([--disable-debugging], [disable runtime debugging messages]),,
+    enable_debug=yes)
 
 if test "$enable_debug" = "yes"; then
    AC_DEFINE(NE_DEBUGGING, 1, [Define to enable debugging])
@@ -32,8 +32,8 @@ fi
 CHECK_READLINE()
 
 AC_ARG_ENABLE(netrc,
-AC_HELP_STRING([--disable-netrc], [enable .netrc support]),,
-enable_netrc=yes)
+AS_HELP_STRING([--disable-netrc],[enable .netrc support]),,
+    enable_netrc=yes)
 
 NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32])
 

--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,6 @@ AC_LIBOBJ(lib/getopt1)])
 dnl Check for strcasecmp
 AC_CHECK_FUNC(strcasecmp,,[AC_LIBOBJ(lib/strcasecmp)])
 
-AC_HEADER_TIME
-
 jm_PREREQ_TEMPNAME
 
 NEON_REPLACE_SNPRINTF()

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,6 @@ AC_DEFINE([_GNU_SOURCE], 1, [Define to enable GNU extensions])
 
 NEON_WITH_LIBS
 
-AC_ISC_POSIX
 AC_PROG_CC
 AC_PROG_INSTALL
 AC_LANG([C])

--- a/configure.ac
+++ b/configure.ac
@@ -73,8 +73,9 @@ AC_HEADER_DIRENT
 
 AC_TYPE_UNSIGNED_LONG_LONG_INT
 
-AC_CHECK_FUNCS(strdup strerror memcpy strcoll tcsetattr getpass stty fchmod strtoull)
 AC_CHECK_HEADERS(sys/time.h pwd.h stdarg.h vmsdir.h memory.h alloca.h ncurses.h sgtty.h termios.h termio.h locale.h)
+
+AC_CHECK_FUNCS(strdup strerror memcpy strcoll tcsetattr getpass stty fchmod strtoull gettimeofday)
 
 AM_GNU_GETTEXT_VERSION([0.20])
 AM_GNU_GETTEXT([external])

--- a/install-sh
+++ b/install-sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # install - install a program, script, or datafile
 
-scriptversion=2018-03-11.20; # UTC
+scriptversion=2020-11-14.01; # UTC
 
 # This originates from X11R5 (mit/util/scripts/install.sh), which was
 # later released in X11R6 (xc/config/util/install.sh) with the
@@ -69,6 +69,11 @@ posix_mkdir=
 # Desired mode of installed file.
 mode=0755
 
+# Create dirs (including intermediate dirs) using mode 755.
+# This is like GNU 'install' as of coreutils 8.32 (2020).
+mkdir_umask=22
+
+backupsuffix=
 chgrpcmd=
 chmodcmd=$chmodprog
 chowncmd=
@@ -99,18 +104,28 @@ Options:
      --version  display version info and exit.
 
   -c            (ignored)
-  -C            install only if different (preserve the last data modification time)
+  -C            install only if different (preserve data modification time)
   -d            create directories instead of installing files.
   -g GROUP      $chgrpprog installed files to GROUP.
   -m MODE       $chmodprog installed files to MODE.
   -o USER       $chownprog installed files to USER.
+  -p            pass -p to $cpprog.
   -s            $stripprog installed files.
+  -S SUFFIX     attempt to back up existing files, with suffix SUFFIX.
   -t DIRECTORY  install into DIRECTORY.
   -T            report an error if DSTFILE is a directory.
 
 Environment variables override the default commands:
   CHGRPPROG CHMODPROG CHOWNPROG CMPPROG CPPROG MKDIRPROG MVPROG
   RMPROG STRIPPROG
+
+By default, rm is invoked with -f; when overridden with RMPROG,
+it's up to you to specify -f if you want it.
+
+If -S is not specified, no backups are attempted.
+
+Email bug reports to bug-automake@gnu.org.
+Automake home page: https://www.gnu.org/software/automake/
 "
 
 while test $# -ne 0; do
@@ -137,7 +152,12 @@ while test $# -ne 0; do
     -o) chowncmd="$chownprog $2"
         shift;;
 
+    -p) cpprog="$cpprog -p";;
+
     -s) stripcmd=$stripprog;;
+
+    -S) backupsuffix="$2"
+        shift;;
 
     -t)
         is_target_a_directory=always
@@ -255,6 +275,10 @@ do
     dstdir=$dst
     test -d "$dstdir"
     dstdir_status=$?
+    # Don't chown directories that already exist.
+    if test $dstdir_status = 0; then
+      chowncmd=""
+    fi
   else
 
     # Waiting for this to be detected by the "$cpprog $src $dsttmp" command
@@ -301,22 +325,6 @@ do
   if test $dstdir_status != 0; then
     case $posix_mkdir in
       '')
-        # Create intermediate dirs using mode 755 as modified by the umask.
-        # This is like FreeBSD 'install' as of 1997-10-28.
-        umask=`umask`
-        case $stripcmd.$umask in
-          # Optimize common cases.
-          *[2367][2367]) mkdir_umask=$umask;;
-          .*0[02][02] | .[02][02] | .[02]) mkdir_umask=22;;
-
-          *[0-7])
-            mkdir_umask=`expr $umask + 22 \
-              - $umask % 100 % 40 + $umask % 20 \
-              - $umask % 10 % 4 + $umask % 2
-            `;;
-          *) mkdir_umask=$umask,go-w;;
-        esac
-
         # With -d, create the new directory with the user-specified mode.
         # Otherwise, rely on $mkdir_umask.
         if test -n "$dir_arg"; then
@@ -326,52 +334,49 @@ do
         fi
 
         posix_mkdir=false
-        case $umask in
-          *[123567][0-7][0-7])
-            # POSIX mkdir -p sets u+wx bits regardless of umask, which
-            # is incompatible with FreeBSD 'install' when (umask & 300) != 0.
-            ;;
-          *)
-            # Note that $RANDOM variable is not portable (e.g. dash);  Use it
-            # here however when possible just to lower collision chance.
-            tmpdir=${TMPDIR-/tmp}/ins$RANDOM-$$
+	# The $RANDOM variable is not portable (e.g., dash).  Use it
+	# here however when possible just to lower collision chance.
+	tmpdir=${TMPDIR-/tmp}/ins$RANDOM-$$
 
-            trap 'ret=$?; rmdir "$tmpdir/a/b" "$tmpdir/a" "$tmpdir" 2>/dev/null; exit $ret' 0
+	trap '
+	  ret=$?
+	  rmdir "$tmpdir/a/b" "$tmpdir/a" "$tmpdir" 2>/dev/null
+	  exit $ret
+	' 0
 
-            # Because "mkdir -p" follows existing symlinks and we likely work
-            # directly in world-writeable /tmp, make sure that the '$tmpdir'
-            # directory is successfully created first before we actually test
-            # 'mkdir -p' feature.
-            if (umask $mkdir_umask &&
-                $mkdirprog $mkdir_mode "$tmpdir" &&
-                exec $mkdirprog $mkdir_mode -p -- "$tmpdir/a/b") >/dev/null 2>&1
-            then
-              if test -z "$dir_arg" || {
-                   # Check for POSIX incompatibilities with -m.
-                   # HP-UX 11.23 and IRIX 6.5 mkdir -m -p sets group- or
-                   # other-writable bit of parent directory when it shouldn't.
-                   # FreeBSD 6.1 mkdir -m -p sets mode of existing directory.
-                   test_tmpdir="$tmpdir/a"
-                   ls_ld_tmpdir=`ls -ld "$test_tmpdir"`
-                   case $ls_ld_tmpdir in
-                     d????-?r-*) different_mode=700;;
-                     d????-?--*) different_mode=755;;
-                     *) false;;
-                   esac &&
-                   $mkdirprog -m$different_mode -p -- "$test_tmpdir" && {
-                     ls_ld_tmpdir_1=`ls -ld "$test_tmpdir"`
-                     test "$ls_ld_tmpdir" = "$ls_ld_tmpdir_1"
-                   }
-                 }
-              then posix_mkdir=:
-              fi
-              rmdir "$tmpdir/a/b" "$tmpdir/a" "$tmpdir"
-            else
-              # Remove any dirs left behind by ancient mkdir implementations.
-              rmdir ./$mkdir_mode ./-p ./-- "$tmpdir" 2>/dev/null
-            fi
-            trap '' 0;;
-        esac;;
+	# Because "mkdir -p" follows existing symlinks and we likely work
+	# directly in world-writeable /tmp, make sure that the '$tmpdir'
+	# directory is successfully created first before we actually test
+	# 'mkdir -p'.
+	if (umask $mkdir_umask &&
+	    $mkdirprog $mkdir_mode "$tmpdir" &&
+	    exec $mkdirprog $mkdir_mode -p -- "$tmpdir/a/b") >/dev/null 2>&1
+	then
+	  if test -z "$dir_arg" || {
+	       # Check for POSIX incompatibilities with -m.
+	       # HP-UX 11.23 and IRIX 6.5 mkdir -m -p sets group- or
+	       # other-writable bit of parent directory when it shouldn't.
+	       # FreeBSD 6.1 mkdir -m -p sets mode of existing directory.
+	       test_tmpdir="$tmpdir/a"
+	       ls_ld_tmpdir=`ls -ld "$test_tmpdir"`
+	       case $ls_ld_tmpdir in
+		 d????-?r-*) different_mode=700;;
+		 d????-?--*) different_mode=755;;
+		 *) false;;
+	       esac &&
+	       $mkdirprog -m$different_mode -p -- "$test_tmpdir" && {
+		 ls_ld_tmpdir_1=`ls -ld "$test_tmpdir"`
+		 test "$ls_ld_tmpdir" = "$ls_ld_tmpdir_1"
+	       }
+	     }
+	  then posix_mkdir=:
+	  fi
+	  rmdir "$tmpdir/a/b" "$tmpdir/a" "$tmpdir"
+	else
+	  # Remove any dirs left behind by ancient mkdir implementations.
+	  rmdir ./$mkdir_mode ./-p ./-- "$tmpdir" 2>/dev/null
+	fi
+	trap '' 0;;
     esac
 
     if
@@ -382,7 +387,7 @@ do
     then :
     else
 
-      # The umask is ridiculous, or mkdir does not conform to POSIX,
+      # mkdir does not conform to POSIX,
       # or it failed possibly due to a race condition.  Create the
       # directory the slow way, step by step, checking for races as we go.
 
@@ -411,7 +416,7 @@ do
           prefixes=
         else
           if $posix_mkdir; then
-            (umask=$mkdir_umask &&
+            (umask $mkdir_umask &&
              $doit_exec $mkdirprog $mkdir_mode -p -- "$dstdir") && break
             # Don't fail if two instances are running concurrently.
             test -d "$prefix" || exit 1
@@ -488,6 +493,13 @@ do
     then
       rm -f "$dsttmp"
     else
+      # If $backupsuffix is set, and the file being installed
+      # already exists, attempt a backup.  Don't worry if it fails,
+      # e.g., if mv doesn't support -f.
+      if test -n "$backupsuffix" && test -f "$dst"; then
+        $doit $mvcmd -f "$dst" "$dst$backupsuffix" 2>/dev/null
+      fi
+
       # Rename the file to the real destination.
       $doit $mvcmd -f "$dsttmp" "$dst" 2>/dev/null ||
 
@@ -502,9 +514,9 @@ do
         # file should still install successfully.
         {
           test ! -f "$dst" ||
-          $doit $rmcmd -f "$dst" 2>/dev/null ||
+          $doit $rmcmd "$dst" 2>/dev/null ||
           { $doit $mvcmd -f "$dst" "$rmtmp" 2>/dev/null &&
-            { $doit $rmcmd -f "$rmtmp" 2>/dev/null; :; }
+            { $doit $rmcmd "$rmtmp" 2>/dev/null; :; }
           } ||
           { echo "$0: cannot unlink or rename $dst" >&2
             (exit 1); exit 1

--- a/lib/getpass.c
+++ b/lib/getpass.c
@@ -61,7 +61,7 @@ static int ttyfd;
 void static save_tty_state(void);
 void static disable_tty_echo(void);
 void static restore_tty_state(void);
-static RETSIGTYPE sigint_handler(int);
+static void sigint_handler(int);
 
 char *fm_getpassword(const char *prompt)
 {
@@ -78,8 +78,8 @@ char *fm_getpassword(const char *prompt)
     register int c;
     FILE *fi;
     static char pbuf[INPUT_BUF_SIZE];
-    RETSIGTYPE (*sig)(int) = 0;	/* initialization pacifies -Wall */
-    RETSIGTYPE sigint_handler(int);
+    void (*sig)(int) = 0;	/* initialization pacifies -Wall */
+    void sigint_handler(int);
     char *ret;
 
     int istty = isatty(0);
@@ -195,7 +195,7 @@ static void restore_tty_state(void)
 #endif
 }
 
-static RETSIGTYPE sigint_handler(int signum)
+static void sigint_handler(int signum)
 {
     restore_tty_state();
     fprintf(stderr, _("\nCaught SIGINT... bailing out.\n"));

--- a/lib/tempname.c
+++ b/lib/tempname.c
@@ -104,8 +104,8 @@
 # define __xstat64(version, path, buf) stat (path, buf)
 #endif
 
-#if ! (HAVE___SECURE_GETENV || defined(_LIBC))
-# define __secure_getenv getenv
+#if ! (HAVE_SECURE_GETENV || defined(_LIBC))
+# define secure_getenv getenv
 #endif
 
 #ifdef _LIBC
@@ -178,7 +178,7 @@ __path_search (char *tmpl, size_t tmpl_len, const char *dir, const char *pfx,
 
   if (try_tmpdir)
     {
-      d = __secure_getenv ("TMPDIR");
+      d = secure_getenv ("TMPDIR");
       if (d != NULL && direxists (d))
 	dir = d;
       else if (dir != NULL && direxists (dir))

--- a/m4/neon/neon.m4
+++ b/m4/neon/neon.m4
@@ -856,8 +856,8 @@ AC_DEFUN([NE_PKG_CONFIG], [
 
 m4_define([ne_cvar], m4_translit(ne_cv_pkg_[$2], [.-], [__]))dnl
 
-AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-if test "$PKG_CONFIG" = "no"; then
+AC_PATH_TOOL(PKG_CONFIG, pkg-config, no)
+if test "x$PKG_CONFIG" = "xno"; then
    : Not using pkg-config
    $4
 else

--- a/po/Makefile.in.in
+++ b/po/Makefile.in.in
@@ -1,13 +1,13 @@
 # Makefile for PO directory in any package using GNU gettext.
 # Copyright (C) 1995-2000 Ulrich Drepper <drepper@gnu.ai.mit.edu>
-# Copyright (C) 2000-2020 Free Software Foundation, Inc.
+# Copyright (C) 2000-2019 Free Software Foundation, Inc.
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Origin: gettext-0.21
+# Origin: gettext-0.20
 GETTEXT_MACRO_VERSION = 0.20
 
 PACKAGE = @PACKAGE@
@@ -90,9 +90,6 @@ DISTFILESDEPS = $(DISTFILESDEPS_$(DIST_DEPENDS_ON_UPDATE_PO))
 
 # Makevars gets inserted here. (Don't remove this line!)
 
-all: all-@USE_NLS@
-
-
 .SUFFIXES:
 .SUFFIXES: .po .gmo .sed .sin .nop .po-create .po-update
 
@@ -110,8 +107,7 @@ all: all-@USE_NLS@
 # the .pot file. This eliminates the need to update the .po files when the
 # .pot file has changed, which would be troublesome if the .po files are put
 # under version control.
-$(GMOFILES): $(srcdir)/$(DOMAIN).pot
-.po.gmo:
+.po.gmo: $(srcdir)/$(DOMAIN).pot
 	@lang=`echo $* | sed -e 's,.*/,,'`; \
 	test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
 	echo "$${cdcmd}rm -f $${lang}.gmo && $(MSGMERGE) $(MSGMERGE_FOR_MSGFMT_OPTION) -o $${lang}.1po $${lang}.po $(DOMAIN).pot && $(GMSGFMT) -c --statistics --verbose -o $${lang}.gmo $${lang}.1po && rm -f $${lang}.1po"; \
@@ -126,6 +122,8 @@ $(GMOFILES): $(srcdir)/$(DOMAIN).pot
 	sed -e '/^#/d' $< > t-$@
 	mv t-$@ $@
 
+
+all: all-@USE_NLS@
 
 all-yes: $(srcdir)/stamp-po
 all-no:
@@ -415,17 +413,12 @@ dist distdir:
 	@$(MAKE) dist2
 # This is a separate target because 'update-po' must be executed before.
 dist2: $(srcdir)/stamp-po $(DISTFILES)
-	@dists="$(DISTFILES)"; \
+	dists="$(DISTFILES)"; \
 	if test "$(PACKAGE)" = "gettext-tools"; then \
 	  dists="$$dists Makevars.template"; \
 	fi; \
 	if test -f $(srcdir)/$(DOMAIN).pot; then \
 	  dists="$$dists $(DOMAIN).pot stamp-po"; \
-	else \
-	  case $(XGETTEXT) in \
-	    :) echo "Warning: Creating a tarball without '$(DOMAIN).pot', because a suitable 'xgettext' program was not found in PATH." 1>&2;; \
-	    *) echo "Warning: Creating a tarball without '$(DOMAIN).pot', because 'xgettext' found no strings to extract. Check the contents of the POTFILES.in file and the XGETTEXT_OPTIONS in the Makevars file." 1>&2;; \
-	  esac; \
 	fi; \
 	if test -f $(srcdir)/ChangeLog; then \
 	  dists="$$dists ChangeLog"; \

--- a/src/cadaver.c
+++ b/src/cadaver.c
@@ -112,7 +112,7 @@ static enum out_state {
 
 /* Protoypes */
 
-static RETSIGTYPE quit_handler(int signo);
+static void quit_handler(int signo);
 
 static void notifier(void *ud, ne_session_status status, 
                      const ne_session_status_info *info);
@@ -559,7 +559,7 @@ static int execute_command(const char *line)
     return ret;
 }
 
-static RETSIGTYPE quit_handler(int sig)
+static void quit_handler(int sig)
 {
     /* Reinstall handler */
     if (child_running) {

--- a/src/search.c
+++ b/src/search.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #endif
 
+#include <ctype.h>
 #include <time.h>
 
 #include <ne_basic.h>


### PR DESCRIPTION
This series of patches:
1. Quoting and syntax updates to configure.ac
2. Set aclocal's source directories (this detects your libreadline custom macro etc.)
3. Remove obsolete macros: AC_ISC_POSIX, AC_HEADER_STDC, AC_HEADER_TIME, AC_TYPE_SIGNAL, jm_*
4. Adds a required `gettext` macro: AM_GNU_GETTEXT_VERSION
5. Enables cross-compiling with `pkg-config`
6. Fixes compiler warnings (missing <ctype.h>)
7. Checks for needed headers and functions
