### PR TITLE
Fix "expect100" option handling.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ AS_HELP_STRING([--disable-netrc],[enable .netrc support]),,
 
 NEON_WITH_LIBS
 
-NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32 33])
+NE_REQUIRE_VERSIONS([0], [29 30 31 32 33])
 
 dnl Don't enable zlib or ACL support in neon
 NEON_WITHOUT_ZLIB

--- a/src/cadaver.c
+++ b/src/cadaver.c
@@ -354,6 +354,7 @@ void open_connection(const char *url)
     ne_redirect_register(sess);
     ne_set_notifier(sess, notifier, NULL);
     ne_set_session_flag(sess, NE_SESSFLAG_PERSIST, get_bool_option(opt_keepalive));
+    ne_set_session_flag(sess, NE_SESSFLAG_EXPECT100, get_bool_option(opt_expect100));
 
     if (session.uri.path == NULL) {
 	session.uri.path = ne_strdup("/");
@@ -387,9 +388,6 @@ void open_connection(const char *url)
 	}
     }
 #endif /* ENABLE_NETRC */
-#ifdef NE_SESSFLAG_EXPECT100
-	ne_set_session_flag(session.sess, NE_SESSFLAG_EXPECT100, get_bool_option(opt_expect100));
-#endif /* NE_SESSFLAG_EXPECT100 */
     session.connected = 0;
 
     ne_set_useragent(session.sess, "cadaver/" PACKAGE_VERSION);

--- a/src/options.c
+++ b/src/options.c
@@ -89,9 +89,7 @@ static struct option {
     /* Booleans */
     B(tolerant, &tolerant, "Tolerate non-WebDAV collections"),
     B(overwrite, &overwrite, "Enable overwrite (e.g. on copy/move operations"),
-#ifdef NE_SESSFLAG_EXPECT100
     B(expect100, &enable_expect, "Enable use of 'Expect: 100-continue' header"),
-#endif /* NE_SESSFLAG_EXPECT100 */
     B(utf8, &presume_utf8, "Presume filenames etc are UTF-8 encoded"),
     B(quiet, &quiet, "Whether to display connection status messages"),
     B(searchall, &searchall, "Whether to search and display all props including dead props"),
@@ -151,18 +149,6 @@ static const struct {
     { "locks", NE_DBG_LOCKS },
     { NULL, 0 }
 };
-
-#ifdef NE_SESSFLAG_EXPECT100
-static void setunset_expect100(void)
-{
-    if (session.connected)
-	return;
-
-    ne_set_session_flag(session.sess, NE_SESSFLAG_EXPECT100, get_bool_option(opt_expect100));
-}
-#else
-#define setunset_expect100() {}
-#endif /* NE_SESSFLAG_EXPECT100 */
 
 static void display_options(void) 
 {
@@ -352,7 +338,6 @@ void execute_set(const char *opt, const char *newv)
 			printf("%s is a boolean option.\n", opt);
 		    } else {
 			*(int *)options[n].holder = 1;
-			setunset_expect100();
 		    }
 		    break;
 		case opt_string:
@@ -393,7 +378,6 @@ void execute_unset(const char *opt, const char *newv)
 		    printf("%s ia a boolean option.\n", opt);
 		} else {
 		    *(int *)options[n].holder = 0;
-		    setunset_expect100();
 		}
 		break;
 	    case opt_string:
@@ -453,7 +437,6 @@ void set_bool_option(enum option_id id, int truth)
     int *opt = get_option(id);
     if (opt != NULL) {
 	*opt = truth;
-	setunset_expect100();
     }
 }
 
@@ -463,7 +446,6 @@ void set_option(enum option_id id, void *newval)
     for (n = 0; options[n].name != NULL; n++) {
 	if (options[n].id == id) {
 	    options[n].holder = newval;
-	    setunset_expect100();
 	    return;
 	}
     }


### PR DESCRIPTION
* configure.ac: Require neon 0.29+

* src/cadaver.c (open_connection): Always call NE_SESSFLAG_EXPECT100 here.

* src/options.c (setunset_expect100): Removed throughout.