### PR TITLE
Document that URL passed must be absolute

### DIFF
--- a/doc/cadaver.1
+++ b/doc/cadaver.1
@@ -2,7 +2,7 @@
 .SH NAME
 cadaver \- A command\-line WebDAV client for Unix. 
 .SH SYNOPSIS
-cadaver [-trp[-r file][-p host[:port]]][-V][-h] http://hostname[:port]/path
+cadaver [-trp[-r file][-p host[:port]]][-V][-h] URL
 .SH DESCRIPTION
 .B cadaver 
 supports file upload, download, on-screen display, namespace operations
@@ -21,6 +21,11 @@ a .netrc file (similar to
 .BR ftp (1)
 - see section "THE .netrc FILE" below).
 .SH OPTIONS
+
+The
+.BR URL
+passed must be an absolute URI using the http: or https URL scheme.
+
 .IP "-t, --tolerant"
 Allow cd/open into non-WebDAV enabled collection; use if the server
 or proxy server has WebDAV compliance problems.

--- a/src/cadaver.c
+++ b/src/cadaver.c
@@ -125,8 +125,8 @@ static int supply_creds_proxy(void *userdata, const char *realm, int attempt,
 static void usage(void)
 {
     printf(_(
-"Usage: %s [OPTIONS] http://hostname[:port]/path\n"
-"  Port defaults to 80, path defaults to '/'\n"
+"Usage: %s [OPTIONS] URL\n"
+"  URL must be an absolute URI using the http: or https: scheme.\n"
 "Options:\n"
 "  -t, --tolerant            Allow cd/open into non-WebDAV enabled collection.\n"
 "  -r, --rcfile=FILE         Read script from FILE instead of ~/.cadaverrc.\n"


### PR DESCRIPTION
```
* src/cadaver.c (usage), doc/cadaver.1: Document that the URL passed
   must be absolute URI.  (fixes #33)
```