### PR TITLE
Suppress char conversion warnings during tab-completion (issue #57):

### DIFF
--- a/src/cadaver.c
+++ b/src/cadaver.c
@@ -97,6 +97,7 @@ struct session session;
 static ne_ssl_client_cert *client_cert;
 
 int tolerant; /* tolerate DAV-enabledness failure */
+int in_completion; /* non-zero if in completion. */
 
 /* Current output state */
 static enum out_state {
@@ -713,6 +714,8 @@ static char **completion(const char *text, int start, int end)
     char **matches = NULL;
     char *sep = strchr(rl_line_buffer, ' ');
 
+    in_completion = 1;
+
     if (start == 0) {
 	matches = rl_completion_matches(text, command_generator);
     }
@@ -740,7 +743,10 @@ static char **completion(const char *text, int start, int end)
 	    }
 	}
 	free(cname);
-    }		    
+    }
+
+    in_completion = 0;
+
     return matches;
 }
 

--- a/src/cadaver.h
+++ b/src/cadaver.h
@@ -103,7 +103,7 @@ extern struct session session;
  * collection. */
 int set_path(const char *newpath);
 
-extern int tolerant;
+extern int tolerant, in_completion;
 
 #ifdef HAVE_LIBREADLINE
 char *command_generator(const char *text, int state);

--- a/src/commands.c
+++ b/src/commands.c
@@ -214,8 +214,10 @@ static char *run_iconv(const char *instr, enum conv_mode mode)
 
     ret = iconv(cd, &inptr, &inbytes, &outptr, &outbytes);
     if (ret == (size_t) -1) {
-        fprintf(stderr, _("cadaver: Warning: Character(s) could not be translated to %s\n"),
-                mode == TO_UTF8 ? "UTF-8" : out_charset);
+        if (!in_completion)
+            fprintf(stderr, _("cadaver: Warning: Character(s) could not "
+                              "be translated to %s\n"),
+                    mode == TO_UTF8 ? "UTF-8" : out_charset);
         /* Make space for trailing "[?]". */
         while (outbytes < 3) {
             outptr -= 1;


### PR DESCRIPTION
```
* src/cadaver.c (completion): Set and clear in_completion.

* src/commands.c (run_iconv): Suppress conversion warning during completion.

* src/cadaver.h: Add in_completion variable.
```