### PR TITLE
Add client-cert-uri handling for neon 0.35+.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, ubuntu-24.04-arm]
+        os: [ubuntu-latest, ubuntu-22.04, ubuntu-24.04-arm]
         install: [true, false]
         bundled: [true, false]
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "neon"]
 	path = neon
 	url = https://github.com/notroj/neon.git
+	branch = 0.34.x

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,13 @@ Changes in release 0.27:
 * Opening a location which does not indicate DAV class 1 support
   is now an error (or a warning in tolerant mode).
 * Removed obsolete BUGS, INTEROP, FAQ documents.
+* Fixed memory leaks in 'cat', 'less' commands.
+* Rewrite of remote tab-completion to work for arbitrary paths.
+* Fixes and improvements for glob (filename expansion) support:
+ - glibc glob() will be used if available in preference to bundled code.
+ - remote wildcards are now expanded across paths (e.g. 'rm */*.html').
+* Add client-cert-uri option for neon 0.35+.
+* Update to neon 0.34.2; neon 0.29.x or later required.
 
 Changes in release 0.26:
 * Argument passed to "cadaver" must now be an absolute URI,

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ NEON_WITH_LIBS
 m4_ifndef([NE_MINIMUM_VERSION],
         [AC_FATAL([NE_MINIMUM_VERSION macro from neon>=0.34.x required to build.])])
 
-NE_MINIMUM_VERSION(0, 28)
+NE_MINIMUM_VERSION(0, 29)
 
 dnl Don't enable zlib or ACL support in neon
 NEON_WITHOUT_ZLIB

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -82,8 +82,7 @@ maybe_add_to_list (netrc_entry **newentry, netrc_entry **list)
    list of entries.  NULL is returned if the file could not be
    parsed. */
 netrc_entry *
-parse_netrc (file)
-     char *file;
+parse_netrc (const char *file)
 {
     FILE *fp;
     char buf[POPBUFSIZE+1], *p, *tok;
@@ -303,9 +302,7 @@ parse_netrc (file)
 /* Return the netrc entry from LIST corresponding to HOST.  NULL is
    returned if no such entry exists. */
 netrc_entry *
-search_netrc (list, host)
-     netrc_entry *list;
-     const char *host;
+search_netrc (netrc_entry *list, const char *host)
 {
     /* Look for the HOST in LIST. */
     while (list)

--- a/lib/netrc.h
+++ b/lib/netrc.h
@@ -55,7 +55,7 @@ __BEGIN_DECLS
 /* Parse FILE as a .netrc file (as described in ftp(1)), and return a
    list of entries.  NULL is returned if the file could not be
    parsed. */
-netrc_entry *parse_netrc __P((char *file));
+netrc_entry *parse_netrc __P((const char *file));
 
 /* Return the netrc entry from LIST corresponding to HOST.  NULL is
    returned if no such entry exists. */

--- a/src/cadaver.c
+++ b/src/cadaver.c
@@ -957,6 +957,13 @@ static void notifier(void *ud, ne_session_status status, const ne_session_status
 	case ne_status_connected:
 	    printf(_("connected.\n"));
 	    break;
+#if NE_MINIMUM_VERSION(0, 35)
+        case ne_status_handshake:
+            printf(_("TLS handshake completed: protocol version %s, cipher %s\n"),
+                   ne_ssl_proto_name(info->hs.protocol),
+                   info->hs.ciphersuite ? info->hs.ciphersuite : _("unknown"));
+            break;
+#endif
         default:
             break;
 	}

--- a/src/commands.c
+++ b/src/commands.c
@@ -796,17 +796,6 @@ static void execute_rmcol(const char *path)
     ne_free(uri_path);
 }
 
-/*
- * --- Path conversion ---
- *
- * Native paths (input from the command-line) are unescaped, relative
- * references (potentially in a non-UTF-8 charset though this is not
- * handled yet).
- *
- * These must be converted to an 'abs_path' in the RFC 3986 grammar,
- * called a 'URI path' for convenience throughout here.
- */
-
 /* Converts an input path (an unescaped, native charset, relative
  * path) to a URI path. */
 static char *path_native_resolver(const char *native_path, int collection)

--- a/src/commands.h
+++ b/src/commands.h
@@ -29,10 +29,17 @@ extern int child_running; /* true when we have a child running */
 /* Returns the command structure for the command of given name. */
 const struct command *get_command(const char *name);
 
-/* Naming conventions:
+/* Naming conventions used here:
  *
- * "native path" -> string in native character encoding
- * "URI path" -> absolute URI path segment (escaped UTF-8 string)
+ * "native character encoding" is the character encoding used for
+ * input/output in the terminal.
+ *
+ * A "native path" is relative path reference in the native character
+ * encoding. Example: "../€.txt".
+ *
+ * A "URI path" is an absolute URI path segment (escaped UTF-8 string)
+ * specifically a "path-absolute" in the RFC 3986 grammar.
+ * Example: "/dav/%e2%82%ac.txt"
  */
 
 /* Convert a URI path to a native path. */

--- a/src/options.c
+++ b/src/options.c
@@ -101,6 +101,8 @@ static struct option {
     S(editor, "Editor to use with `edit' command"),
     S2("client-cert", opt_clicert,
        "Client certificate to use for SSL connections."),
+    S2("client-cert-uri", opt_clicert_uri,
+       "Client certificate URI to use for SSL connections."),
     S(namespace, "Namespace to use for propset/propget commands."),
     S(pager, "Command to run for less/more commands."),
     S(proxy, "Hostname of proxy server"),

--- a/src/options.h
+++ b/src/options.h
@@ -28,6 +28,7 @@ enum option_id {
     opt_expect100,
     opt_editor,
     opt_clicert,
+    opt_clicert_uri,
     opt_namespace,
     opt_quiet,
     opt_proxy,


### PR DESCRIPTION
```
Add client-cert-uri handling for neon 0.35+.

* src/options.c, src/options.h: Add client-cert-uri option

* src/cadaver.c (setup_ssl): Merge client cert handling into here, simplify.
```