### PR TITLE
Add 'resumeget' command

### DIFF
--- a/src/cadaver.h
+++ b/src/cadaver.h
@@ -58,7 +58,7 @@ enum command_id {
     cmd_steal, cmd_discover, cmd_showlocks, cmd_propedit, cmd_propnames,
     cmd_propget, cmd_propset, cmd_propdel, cmd_chexec, cmd_edit, cmd_logout,
     cmd_describe, cmd_search, cmd_version, cmd_checkin, cmd_checkout,
-    cmd_uncheckout, cmd_history, cmd_label, cmd_head,
+    cmd_uncheckout, cmd_history, cmd_label, cmd_head, cmd_resumeget,
     cmd_unknown
 /* DON'T FORGET TO ADD A NEW COMMAND ALIAS WHEN YOU ADD A NEW COMMAND */
 };


### PR DESCRIPTION
```
Add 'resumeget' command (closes #67), which uses a ranged GET to
resume the download of an existing local file:

* src/commands.c (do_get): Renamed from execute_get, take a resume argument. Use ne_get_range() for resumption. Open the file with O_EXCL if creating a file for the non-resumption case.

* src/cadaver.h: Add cmd_resumeget command.
```